### PR TITLE
Laravel 6.0 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   "require": {
     "php": ">=7.1",
     "ibericode/vat": "^1.2",
-    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
-    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*"
+    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.3|^7.0",


### PR DESCRIPTION
When you want to update your laravel to 6.0 and use laravel-vat, this commit may helps