### PR TITLE
Improve compatibility with Laravel from 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   "require": {
     "php": ">=7.1",
     "ibericode/vat": "^1.2",
-    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*|6.2.*|6.3.*",
-    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*|6.2.*|6.3.*"
+    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.*",
+    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.3|^7.0",


### PR DESCRIPTION
Avoid ongoing issues with compatibility. This technically is doing the same this package has always done and assumes support for the current major version.